### PR TITLE
Remove 'dafuq' from PGP Public Key comment

### DIFF
--- a/app/utils/pgp.js
+++ b/app/utils/pgp.js
@@ -13,7 +13,7 @@ function applyFelonyBranding(openpgpBrandedKey) {
   let output
   output = openpgpBrandedKey.replace(/Version: OpenPGP\.js [^<]\d\.\d\.\d/g,
     'Version: 🔑 Felony (PGP made easy) v0.0.1')
-  output = output.replace('Comment: http://openpgpjs.org', 'Comment: 👀 How dafuq do I use this? --> http://felony.io 😉')
+  output = output.replace('Comment: http://openpgpjs.org', 'Comment: 👀 How do I use this? --> http://felony.io 😉')
   return output
 }
 


### PR DESCRIPTION
Really hate to be an ass. I like the informal style this application has, but using slang like dafuq isn't that professional. Consider ditching 'dafuq' from Public Keys by default.

Will try to make some actually useful contributions in the future;).