### PR TITLE
Update default electron version and remove crash reporter

### DIFF
--- a/main.development.js
+++ b/main.development.js
@@ -6,7 +6,6 @@ let menu
 let template
 let mainWindow = null
 
-crashReporter.start()
 const feedUrl = `https://felony-app-update.herokuapp.com/update/${process.platform}_${process.arch}/${version}`
 
 if (process.env.NODE_ENV !== 'development') {

--- a/package.js
+++ b/package.js
@@ -52,7 +52,7 @@ if (version) {
   // use the same version as the currently-installed electron-prebuilt
   exec('npm list electron-prebuilt --dev', (err, stdout) => {
     if (err) {
-      DEFAULT_OPTS.version = '0.37.6'
+      DEFAULT_OPTS.version = '1.2.6'
     } else {
       DEFAULT_OPTS.version = stdout.split('electron-prebuilt@')[1].replace(/\s/g, '')
     }


### PR DESCRIPTION
These two things fixed my issues with the blank window (see #33)

By default it was installing an older version of electron which seems to be causing some problems.

I am now able to build and run it as expected.