### PR TITLE
Fix Windows enviroment variable

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -14,7 +14,7 @@ IF REQUESTING A FEATURE, delete the Bug Report section.
 NOTE: Please be sure to attach a logfile if available.  Here's where you can find the logfile:
 Linux: ~/.config/Felony/log.log
 OS X: ~/Library/Logs/Felony/log.log
-Windows: $HOME/AppData/Roaming/Felony/log.log
+Windows: %AppData%/Felony/log.log
 -->
 
 #### Expected behavior

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,4 +16,4 @@ If your log file contains any information please attach it.
 
 - Linux: ~/.config/Felony/log.log
 - OS X: ~/Library/Logs/Felony/log.log
-- Windows: $HOME/AppData/Roaming/Felony/log.log
+- Windows: %AppData%/Felony/log.log


### PR DESCRIPTION
#### What's in this pull request?
The Windows environment variable in the CONTRIBUTING.md is wrong - there is no default environment variable called $HOME(there is HOMEPATH though) in Windows, and the access to the environment variable is wrong (a dollar is used)

#### Changes proposed
Change $HOME/AppData/Roaming/ to %AppData%
